### PR TITLE
Bugs/redrawing component

### DIFF
--- a/addon/-private/radar/models/element.js
+++ b/addon/-private/radar/models/element.js
@@ -1,9 +1,3 @@
-import FastArray from 'perf-primitives/fast-array';
-
-const ELEMENT_POOL = new FastArray(200, 'Element Pool');
-const STYLE_POOL = new FastArray(200, 'Style Pool');
-const RECT_POOL = new FastArray(200, 'Rect Pool');
-
 export const LayoutProps = [
   'position',
   'box-sizing',
@@ -45,13 +39,6 @@ export class Style {
   }
 
   static create(values) {
-    let po = STYLE_POOL.pop();
-
-    if (po) {
-      po.init(values);
-      return po;
-    }
-
     return new Style(values);
   }
 
@@ -59,8 +46,6 @@ export class Style {
     for (let i = 0; i < LayoutProps.length; i++) {
       this[LayoutProps[i]] = undefined;
     }
-
-    STYLE_POOL.push(this);
   }
 }
 
@@ -85,13 +70,6 @@ export class Rect {
   }
 
   static create(values) {
-    let po = RECT_POOL.pop();
-
-    if (po) {
-      po.init(values);
-      return po;
-    }
-
     return new Rect(values);
   }
 
@@ -99,8 +77,6 @@ export class Rect {
     for (let i = 0; i < RECT_PROPS.length; i++) {
       this[RECT_PROPS[i]] = undefined;
     }
-
-    RECT_POOL.push(this);
   }
 }
 
@@ -146,13 +122,6 @@ export default class VirtualElement {
   }
 
   static create(styles, element) {
-    let po = ELEMENT_POOL.pop();
-
-    if (po) {
-      po.init(styles, element);
-      return po;
-    }
-
     return new VirtualElement(styles, element);
   }
 
@@ -160,8 +129,6 @@ export default class VirtualElement {
     this.element = undefined;
     this.style = undefined;
     this.rect = undefined;
-
-    ELEMENT_POOL.push(this);
   }
 
 }

--- a/addon/-private/radar/models/list-satellite.js
+++ b/addon/-private/radar/models/list-satellite.js
@@ -1,6 +1,4 @@
 import Satellite from './satellite';
-import FastArray from 'perf-primitives/fast-array';
-const LIST_SAT_POOL = new FastArray(200, 'ListSatellite Pool');
 
 export default class ListSatellite extends Satellite {
 
@@ -21,19 +19,10 @@ export default class ListSatellite extends Satellite {
   }
 
   static create(options) {
-    let sat = LIST_SAT_POOL.pop();
-
-    if (sat) {
-      sat.init(options);
-      return sat;
-    }
-
     return new ListSatellite(options);
   }
 
   destroy() {
     this._destroy();
-
-    LIST_SAT_POOL.push(this);
   }
 }

--- a/addon/-private/radar/models/satellite.js
+++ b/addon/-private/radar/models/satellite.js
@@ -1,9 +1,6 @@
 import Geography from './geography';
 import VirtualElement from './element';
-import FastArray from 'perf-primitives/fast-array';
 import noop from '../utils/noop-fn';
-
-const SAT_POOL = new FastArray(200, 'Satellite Pool');
 
 export default class Satellite {
 
@@ -109,19 +106,10 @@ export default class Satellite {
   }
 
   static create(options) {
-    let sat = SAT_POOL.pop();
-
-    if (sat) {
-      sat.init(options);
-      return sat;
-    }
-
     return new Satellite(options);
   }
 
   destroy() {
     this._destroy();
-
-    SAT_POOL.push(this);
   }
 }

--- a/addon/-private/radar/utils/scroll-handler.js
+++ b/addon/-private/radar/utils/scroll-handler.js
@@ -13,9 +13,9 @@ export class ScrollHandler {
   }
 
   addElementHandler(element, handler) {
-    let index = this.length++;
-
     if (this.elements.indexOf(element) === -1) {
+      let index = this.length++;
+
       if (index === this.maxLength) {
         this.maxLength *= 2;
         this.elements.length = this.maxLength;

--- a/addon/components/vertical-item/component.js
+++ b/addon/components/vertical-item/component.js
@@ -3,7 +3,8 @@ import layout from './template';
 import getOwner from 'ember-getowner-polyfill';
 
 const {
-  Component
+  Component,
+  run
   } = Ember;
 
 /*
@@ -52,7 +53,7 @@ export default Component.extend({
     if (!this.alwaysUseDefaultHeight) {
       this.element.style.height = undefined;
     }
-    this.updateHeight();
+    run.schedule('afterRender', this, this.updateHeight);
   },
 
   /*

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,6 +15,7 @@ Router.map(function() {
     this.route('html-gl');
     this.route('large-grid');
     this.route('reduce-debug');
+    this.route('redraw');
   });
 
   this.route('mixins', function() {

--- a/tests/dummy/app/screens/examples/index/template.hbs
+++ b/tests/dummy/app/screens/examples/index/template.hbs
@@ -19,6 +19,9 @@
                 <li>
                   {{#link-to 'examples.large-grid'}}Large Grid{{/link-to}} (takes a while to load)
                 </li>
+                <li>
+                  {{#link-to 'examples.redraw'}}Redraw{{/link-to}}
+                </li>
             </ul>
         </div>
         <div class="col-sm-8 bg-success">

--- a/tests/dummy/app/screens/examples/redraw/controller.js
+++ b/tests/dummy/app/screens/examples/redraw/controller.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+import { getDynamicImages } from 'dummy/lib/get-images';
+
+const {
+  Controller
+  } = Ember;
+
+export default Controller.extend({
+
+  show: true,
+
+  _generateData({ size=50, from=0 }) {
+    const data = Ember.A();
+    const end = from + size;
+
+    for (let i = from; i < end; i++) {
+      data.pushObject(Ember.Object.create({
+        name: `item ${i}`,
+        height:`${20 + ((i % 5) * 10)}px`
+      }));
+    }
+
+    return data;
+  },
+
+  actions: {
+    lastReached() {
+      const newData = this._generateData({ from: this.get('model.length') });
+      this.get('model').pushObjects(newData);
+    },
+    redraw() {
+      Ember.run(() => this.set('show', false));
+      this.set('show', true);
+    },
+    resetModel() {
+      this.set('model', this._generateData({ size: 100 }));
+    }
+  }
+
+});

--- a/tests/dummy/app/screens/examples/redraw/route.js
+++ b/tests/dummy/app/screens/examples/redraw/route.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import { getDynamicImages } from 'dummy/lib/get-images';
+
+const {
+  Route
+  } = Ember;
+
+export default Route.extend({
+
+  model() {
+    const items = Ember.A([]);
+    for (let i = 0; i < 100; i++) {
+      items.pushObject(Ember.Object.create({
+        name: `item ${i}`,
+        height:`${20 + ((i % 5) * 10)}px`
+      }));
+    }
+    return items;
+  }
+
+});

--- a/tests/dummy/app/screens/examples/redraw/template.hbs
+++ b/tests/dummy/app/screens/examples/redraw/template.hbs
@@ -1,0 +1,32 @@
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-sm-7">
+          {{!- BEGIN-SNIPPET flexible-layout-example }}
+          {{#if show}}
+            <div class="table-wrapper">
+              {{#vertical-collection
+                content=model
+                defaultHeight=20
+                alwaysUseDefaultHeight=false
+                visibleBuffer=2
+                useContentProxy=false
+                lastReached="lastReached"
+                as |item|
+              }}
+                <div style="height: {{item.height}}">{{item.name}}</div>
+              {{/vertical-collection}}
+            </div>
+          {{/if}}
+          {{!- END-SNIPPET }}
+        </div>
+        <div class="col-sm-5">
+            <h3>Scenarios</h3>
+            <p>
+                <button {{action "redraw"}}>Redraw</button>
+            </p>
+            <p>
+                <button {{action "resetModel"}}>Reset model</button>
+            </p>
+        </div>
+    </div>
+</div>

--- a/tests/integration/components/vertical-collection-test.js
+++ b/tests/integration/components/vertical-collection-test.js
@@ -71,6 +71,39 @@ test('Adds classes to vertical-items', function(assert) {
   });
 });
 
+test('Scroll to last item when actual item sizes are significantly larger than default item size.', function(assert) {
+  assert.expect(1);
+
+  this.set('items', new Array(50).fill({ text: 'b' }));
+
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection
+      defaultHeight=10
+      alwaysUseDefaultHeight=false
+      bufferSize=0
+      content=items as |item i|}}
+      <div style="height: 100px;">{{item.text}} {{i}}</div>
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  const scrollable = this.$('.scrollable');
+  const waitForScroll = new Ember.RSVP.Promise((resolve) => scrollable.scroll(resolve));
+
+  return wait()
+    .then(() => {
+      // Jump to bottom.
+      scrollable.scrollTop(scrollable.get(0).scrollHeight);
+    })
+    .then(waitForScroll)
+    .then(wait)
+    .then(() => {
+      assert.equal(scrollable.find('div:last').html(), 'b 49', 'the last item in the list should be rendered');
+    });
+});
+
+
 /*
 test("The Collection Reveals it's children when `renderAllInitially` is true.", function(assert) {
   assert.expect(1);


### PR DESCRIPTION
This is a patch to fix the issue when the vertical-collection component is recreated with vertical-items with dynamic height.

**Problem**
Having a vertical-collection with items with different height, if the vertical-collection component is recreated, once it's recreated and the user scrolls down a bit to see more elements we found some gaps between elements.

Following the rabbit found that the models are using this FastArray class, which keeps the instances of the models once they are destroyed and reuse them when they are recreated next time. I quickly checked the destroy method for these models classes but couldn't find the leak / problem on the cleanup. Maybe the radar is caching some values?

**Patch**
This patch removes the FastArray (downgrading the performance I guess, since now, every time that we re-render the component, we're creating the instances of the models again).
