### PR TITLE
Stop tests from erroring when component is destroyed before sendAction call happens

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -339,7 +339,9 @@ const VerticalCollection = Component.extend({
     // this MUST be async or glimmer will freak
     scheduler.schedule('affect', () => {
       setTimeout(() => {
-        this.sendAction(name, context, K);
+        if (!(this.isDestroying || this.isDestroyed)) {
+          this.sendAction(name, context, K);
+        }
       });
     });
   },


### PR DESCRIPTION
Stop tests from erroring when component is destroyed before sendAction call happens